### PR TITLE
Add running-state quick reset (I Drank Water!)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Water Reminder sits quietly on your desktop and fires a periodic hydration remin
 - Pulse the entire app UI once per second until you acknowledge, snooze, or stop the reminder, darkening in light mode and brightening in dark mode.
 
 If you want to be honest about actually drinking water, enable **Require Acknowledgment**: the timer pauses after every reminder and only resumes once you click "I Drank Water!". You can also snooze a reminder to delay it by a configurable number of minutes.
+While the timer is already running, a separate `I Drank Water!` control in the main controls card lets you immediately restart the countdown from the full configured interval without stopping the current reminder session or resetting the reminder count.
 If sound is enabled, you can also have the app repeat the alert tone every 10 seconds until you acknowledge or snooze the reminder.
 
 Settings are automatically saved to disk with a short debounce — nothing is lost if you close and reopen the app.
@@ -48,6 +49,7 @@ Settings are automatically saved to disk with a short debounce — nothing is lo
 | Launch auto-start | Optionally starts a fresh reminder session automatically on app launch |
 | UI flash animation | Full-screen saturation + brightness pulse on every reminder; auto-clears when you acknowledge, snooze, or stop |
 | Pause / resume | Saves exact remaining time; counter is preserved |
+| Running-state quick reset | `I Drank Water!` restarts the current countdown from the full interval while staying in `Running` |
 | Persistent settings | Saved to `settings.json` in the OS app data directory |
 | Settings validation | Backend rejects invalid values; errors shown in the UI |
 
@@ -61,6 +63,7 @@ Stopped → Running → (reminder fires) → WaitingAck ⟶ Running
 
 - **Stopped** – timer inactive, counter reset to 0.
 - **Running** – counting down; a live countdown is shown in the UI.
+- **Running actions** – you can pause, stop, reset the session, snooze, or click `I Drank Water!` to restart the countdown from the full interval immediately.
 - **Paused** – countdown suspended; remaining time and counter both preserved.
 - **WaitingAck** – shown when *Require Acknowledgment* is on; next interval does not start until you acknowledge or snooze.
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -472,6 +472,34 @@ fn snooze_reminder(
     Ok(snap)
 }
 
+/// Restart the active countdown from the full configured interval.
+///
+/// Only valid while status is `Running`. The existing timer thread keeps the
+/// same generation and simply observes the updated fire time on its next loop.
+#[tauri::command]
+fn reset_active_countdown(
+    state: State<'_, SharedState>,
+    app_handle: AppHandle,
+) -> Result<StateSnapshot, String> {
+    let mut s = state.lock().map_err(|e| e.to_string())?;
+
+    if s.status != ReminderStatus::Running {
+        return Err("Countdown can only be reset while reminders are running.".into());
+    }
+
+    s.next_fire_at = Some(
+        Instant::now() + Duration::from_secs(s.config.interval_minutes as u64 * 60),
+    );
+    s.remaining_when_paused = None;
+
+    let snap = snapshot(&s);
+    drop(s);
+
+    stop_window_attention(&app_handle);
+
+    Ok(snap)
+}
+
 /// Return the current state without mutating anything.  Called by the
 /// front-end every second to keep the countdown display in sync.
 #[tauri::command]
@@ -804,6 +832,7 @@ pub fn run() {
             pause_reminders,
             resume_reminders,
             reset_reminders,
+            reset_active_countdown,
             snooze_reminder,
             acknowledge_reminder,
             get_status,

--- a/src/App.css
+++ b/src/App.css
@@ -494,6 +494,12 @@ fieldset:disabled .radio-label {
   gap: 10px;
 }
 
+.secondary-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
 /* ── Base button ── */
 .btn {
   display: inline-flex;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -605,6 +605,19 @@ function App() {
     }
   }, [clearFlashEffect]);
 
+  /** Restart the active countdown from the full configured interval. */
+  const handleDrinkWater = useCallback(async () => {
+    try {
+      setError(null);
+      const snapshot = await invoke<StateSnapshot>("reset_active_countdown");
+      setRemState(snapshot);
+      setShowSnoozeBanner(false);
+      clearFlashEffect();
+    } catch (e) {
+      setError(String(e));
+    }
+  }, [clearFlashEffect]);
+
   // ---------------------------------------------------------------------------
   // Derived state flags used to drive the UI
   // ---------------------------------------------------------------------------
@@ -751,15 +764,28 @@ function App() {
           </button>
         </div>
 
-        {/* Snooze button – shown when timer is active (but not WaitingAck, which has its own card) */}
-        {showSnooze && !isWaitingAck && (
-          <button
-            className="btn btn-snooze"
-            onClick={handleSnooze}
-            aria-label={`Snooze reminder for ${remState.config.snooze_minutes} minutes`}
-          >
-            💤 Snooze ({remState.config.snooze_minutes} min)
-          </button>
+        {/* Running-state reminder actions live below the primary controls. */}
+        {!isWaitingAck && (
+          <div className="secondary-actions">
+            <button
+              className="btn btn-acknowledge"
+              onClick={handleDrinkWater}
+              disabled={!isRunning}
+              aria-label="I drank water and want to restart the reminder interval"
+            >
+              ✓ I Drank Water!
+            </button>
+
+            {showSnooze && (
+              <button
+                className="btn btn-snooze"
+                onClick={handleSnooze}
+                aria-label={`Snooze reminder for ${remState.config.snooze_minutes} minutes`}
+              >
+                💤 Snooze ({remState.config.snooze_minutes} min)
+              </button>
+            )}
+          </div>
         )}
       </section>
 


### PR DESCRIPTION
Introduce a running-state quick reset that restarts the active countdown without stopping the session. Adds a new Tauri command reset_active_countdown (updates next_fire_at and clears remaining_when_paused) and registers it in the app command list. Frontend: adds handleDrinkWater to invoke the command, a new "I Drank Water!" button placed in a .secondary-actions container (with corresponding CSS), and adjusts snooze placement. README updated to document the feature and UI/state changes.