### PR TITLE
Add 'always on top while waiting' feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Water Reminder sits quietly on your desktop and fires a periodic hydration remin
 - Send a native OS desktop notification.
 - Play a short alert tone synthesized in the browser audio engine (no external audio file needed).
 - Bring the app window to the foreground.
+- **Keep the window always on top** until you acknowledge or snooze (optional; requires *Bring window to front* to be enabled).
 - Flash the Windows taskbar or bounce the macOS dock icon.
 - Optionally minimize the app window to the taskbar after you acknowledge a reminder.
 - Pulse the entire app UI once per second until you acknowledge, snooze, or stop the reminder, darkening in light mode and brightening in dark mode.
@@ -47,6 +48,7 @@ Settings are automatically saved to disk with a short debounce — nothing is lo
 | Window focus | Surfaces the app on reminder; on Windows it does not steal focus |
 | Taskbar / dock flash | Flashes taskbar (Windows) or bounces dock icon (macOS) |
 | Acknowledge auto-minimize | Optionally minimizes the window after `I Drank Water!` in `WaitingAck` |
+| Always-on-top while waiting | Keeps the window above all other windows during `WaitingAck`; requires *Focus window* to be enabled |
 | Theme preference | Follow system, always light, or always dark |
 | Launch auto-start | Optionally starts a fresh reminder session automatically on app launch |
 | UI flash animation | Full-screen saturation + brightness pulse on every reminder; auto-clears when you acknowledge, snooze, or stop |
@@ -84,6 +86,7 @@ Stopped → Running → (reminder fires) → WaitingAck ⟶ Running
 | Play sound | On | On / Off | Alert tone on reminder |
 | Repeat sound until action | On | On / Off | Replays every 10 seconds while waiting for acknowledgment |
 | Focus window | On | On / Off | Brings window to front; on Windows this avoids stealing focus |
+| Always on top while waiting | Off | On / Off | Keeps the window above all others during `WaitingAck`; only available when *Focus window* is on |
 | Flash taskbar | On | On / Off | Flashes taskbar / bounces dock icon on reminder |
 | Minimize on acknowledge | Off | On / Off | Minimizes the window after acknowledging a pending reminder |
 
@@ -171,7 +174,7 @@ The packaged installer is written to `src-tauri/target/release/bundle/`.
 
 ## Platform notes
 
-- **Windows** – taskbar flash uses the `Critical` attention type, which flashes both the window frame and the taskbar button until the app is focused. If **Focus window** is enabled, the app is also raised above other windows without taking keyboard focus.
+- **Windows** – taskbar flash uses the `Critical` attention type, which flashes both the window frame and the taskbar button until the app is focused. If **Focus window** is enabled, the app is also raised above other windows without taking keyboard focus. If **Always on top while waiting** is also enabled, the window stays above all other windows while `WaitingAck` is active and reverts to normal z-order once you acknowledge or snooze.
 - **macOS** – dock bounce uses the `Critical` attention type (continuous bounce until focused); bundle identifier is `com.waterreminder.desktop`.
 - **Linux** – taskbar flash behaviour depends on the window manager (GNOME, KDE, i3, etc.) and is not guaranteed.
 - **Closing the app** – if the timer is `Stopped`, closing the window exits immediately. If a reminder session is active (`Running`, `Paused`, or `WaitingAck`), the app asks for confirmation before closing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "water-reminder",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "water-reminder",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4663,7 +4663,7 @@ dependencies = [
 
 [[package]]
 name = "water-reminder"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "raw-window-handle",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "water-reminder"
-version = "0.1.0"
+version = "0.1.2"
 description = "A configurable water reminder application built with Tauri v2"
 authors = []
 edition = "2021"
@@ -36,7 +36,10 @@ serde_json = "1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 raw-window-handle = "0.6"
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging"] }
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_UI_WindowsAndMessaging",
+] }
 
 # ── Release profile – smaller, faster binary ──────────────────────────────
 [profile.release]

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
     "core:default",
     "dialog:default",
     "notification:default",
-    "core:window:allow-destroy"
+    "core:window:allow-destroy",
+    "core:window:allow-set-always-on-top"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -105,6 +105,10 @@ pub struct ReminderConfig {
     /// pending reminder.
     #[serde(default)]
     pub minimize_on_acknowledge: bool,
+    /// When `true`, the window is kept always-on-top while the app is in the
+    /// `WaitingAck` state.  Only has effect when `focus_window` is also `true`.
+    #[serde(default)]
+    pub always_on_top_while_waiting: bool,
 }
 
 impl Default for ReminderConfig {
@@ -121,6 +125,7 @@ impl Default for ReminderConfig {
             focus_window: true,
             flash_taskbar: true,
             minimize_on_acknowledge: false,
+            always_on_top_while_waiting: false,
         }
     }
 }
@@ -388,7 +393,7 @@ fn stop_reminders(
     Ok(snap)
 }
 
-/// Pause the timer.  The remaining time until the next reminder is saved so
+/// Pause the timer.The remaining time until the next reminder is saved so
 /// that `resume_reminders` can pick up exactly where it left off.
 ///
 /// The reminder count is intentionally preserved on pause so that resuming
@@ -580,7 +585,7 @@ fn acknowledge_reminder(
     Ok(snap)
 }
 
-// ── Timer thread ──────────────────────────────────────────────────────────────
+// ── Timer thread──────────────────────────────────────────────────────────────
 
 /// Spawn a background thread that drives the reminder schedule.
 ///

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Water Reminder",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "identifier": "com.waterreminder.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.css
+++ b/src/App.css
@@ -682,6 +682,15 @@ fieldset:disabled .toggle-label {
   cursor: not-allowed;
 }
 
+.toggle-label--disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.toggle-label--disabled input {
+  cursor: not-allowed;
+}
+
 fieldset:disabled .toggle-label input {
   cursor: not-allowed;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,9 @@ interface ReminderConfig {
   flash_taskbar: boolean;
   /** When true, the window is minimized after acknowledging a pending reminder. */
   minimize_on_acknowledge: boolean;
+  /** When true, the window is kept always on top while waiting for acknowledgment.
+   *  Only has effect when focus_window is also true. */
+  always_on_top_while_waiting: boolean;
 }
 
 /** Possible states of the reminder timer. */
@@ -117,6 +120,7 @@ const DEFAULT_CONFIG: ReminderConfig = {
   focus_window: true,
   flash_taskbar: true,
   minimize_on_acknowledge: false,
+  always_on_top_while_waiting: false,
 };
 
 /** Default state when the app first loads. */
@@ -157,6 +161,9 @@ function App() {
   const [formFlashTaskbar, setFormFlashTaskbar] = useState(DEFAULT_CONFIG.flash_taskbar);
   const [formMinimizeOnAcknowledge, setFormMinimizeOnAcknowledge] = useState(
     DEFAULT_CONFIG.minimize_on_acknowledge,
+  );
+  const [formAlwaysOnTopWhileWaiting, setFormAlwaysOnTopWhileWaiting] = useState(
+    DEFAULT_CONFIG.always_on_top_while_waiting,
   );
   const [systemPrefersDark, setSystemPrefersDark] = useState(getSystemPrefersDark);
 
@@ -267,6 +274,7 @@ function App() {
         setFormFocusWindow(snapshot.config.focus_window);
         setFormFlashTaskbar(snapshot.config.flash_taskbar);
         setFormMinimizeOnAcknowledge(snapshot.config.minimize_on_acknowledge);
+        setFormAlwaysOnTopWhileWaiting(snapshot.config.always_on_top_while_waiting);
         // Mark the initial load as done so subsequent changes auto-save.
         isInitialLoadRef.current = false;
       })
@@ -300,6 +308,7 @@ function App() {
         focus_window: formFocusWindow,
         flash_taskbar: formFlashTaskbar,
         minimize_on_acknowledge: formMinimizeOnAcknowledge,
+        always_on_top_while_waiting: formAlwaysOnTopWhileWaiting,
       };
 
       // save_config validates, persists to disk, and updates the in-memory config.
@@ -327,6 +336,7 @@ function App() {
     formFocusWindow,
     formFlashTaskbar,
     formMinimizeOnAcknowledge,
+    formAlwaysOnTopWhileWaiting,
   ]);
 
   useEffect(() => {
@@ -367,6 +377,30 @@ function App() {
       flashTimerRef.current = null;
     }
   }, []);
+
+  // ---------------------------------------------------------------------------
+  // Manage always-on-top state in the frontend.
+  //
+  // We do this in TypeScript rather than from the Rust timer thread because
+  // the timer thread calls Win32 SetWindowPos with SWP_ASYNCWINDOWPOS (required
+  // for cross-thread calls), and bring_window_to_front posts TOPMOST then
+  // NOTOPMOST to the message queue.  Any Win32 call we make from the timer
+  // thread races with those queued messages.  By the time the TypeScript effect
+  // runs, all queued Win32 messages have long been processed, so our IPC call
+  // to setAlwaysOnTop wins cleanly.
+  // ---------------------------------------------------------------------------
+  useEffect(() => {
+    if (remState.status !== "WaitingAck" || !formFocusWindow || !formAlwaysOnTopWhileWaiting) {
+      return;
+    }
+
+    const appWindow = getCurrentWindow();
+    void appWindow.setAlwaysOnTop(true);
+
+    return () => {
+      void appWindow.setAlwaysOnTop(false);
+    };
+  }, [remState.status, formFocusWindow, formAlwaysOnTopWhileWaiting]);
 
   useEffect(() => {
     const previousStatus = previousReminderStatusRef.current;
@@ -534,6 +568,7 @@ function App() {
     focus_window: formFocusWindow,
     flash_taskbar: formFlashTaskbar,
     minimize_on_acknowledge: formMinimizeOnAcknowledge,
+    always_on_top_while_waiting: formAlwaysOnTopWhileWaiting,
   }), [
     formInterval,
     isInfinite,
@@ -547,6 +582,7 @@ function App() {
     formFocusWindow,
     formFlashTaskbar,
     formMinimizeOnAcknowledge,
+    formAlwaysOnTopWhileWaiting,
   ]);
 
   useEffect(() => {
@@ -1044,6 +1080,15 @@ function App() {
                     onChange={(e) => setFormFocusWindow(e.target.checked)}
                   />
                   <span>Bring window to front (without focus on Windows)</span>
+                </label>
+                <label className={`toggle-label${!formFocusWindow ? " toggle-label--disabled" : ""}`}>
+                  <input
+                    type="checkbox"
+                    checked={formAlwaysOnTopWhileWaiting}
+                    disabled={!formFocusWindow}
+                    onChange={(e) => setFormAlwaysOnTopWhileWaiting(e.target.checked)}
+                  />
+                  <span>Keep window always on top while waiting for acknowledgment</span>
                 </label>
                 <label className="toggle-label">
                   <input


### PR DESCRIPTION
Introduce a new setting to keep the app window always-on-top while a reminder is in WaitingAck. Adds a config field (Rust + TypeScript), a UI toggle (disabled when "Focus window" is off), and a frontend effect that calls the Tauri window API to setAlwaysOnTop during WaitingAck. Grants the new Tauri capability (core:window:allow-set-always-on-top), updates defaults (off), adds small CSS for disabled toggle styling, and bumps package/tauri crate versions and metadata accordingly. Also includes minor formatting/comments tweaks.