### PR TITLE
Bump version to 0.1.5 and fix Windows flash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "water-reminder",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "water-reminder",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "water-reminder",
   "private": true,
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4655,7 +4655,7 @@ dependencies = [
 
 [[package]]
 name = "water-reminder"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "raw-window-handle",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "water-reminder"
-version = "0.1.4"
+version = "0.1.5"
 description = "A configurable water reminder application built with Tauri v2"
 authors = []
 edition = "2021"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -751,36 +751,40 @@ fn bring_window_to_front(app_handle: &AppHandle) {
 }
 
 #[cfg(target_os = "windows")]
-fn bring_window_to_front_without_focus_on_windows(app_handle: &AppHandle) {
+fn hwnd_from_main_window(app_handle: &AppHandle) -> Option<windows_sys::Win32::Foundation::HWND> {
     use raw_window_handle::{HasWindowHandle, RawWindowHandle};
-    use windows_sys::Win32::{
-        Foundation::HWND,
-        UI::WindowsAndMessaging::{
-            HWND_NOTOPMOST, HWND_TOPMOST, SWP_ASYNCWINDOWPOS, SWP_NOACTIVATE, SWP_NOMOVE,
-            SWP_NOSIZE, SWP_SHOWWINDOW, SW_SHOWNOACTIVATE, SetWindowPos, ShowWindow,
-        },
-    };
+    use windows_sys::Win32::Foundation::HWND;
 
     let Some(win) = app_handle.get_webview_window("main") else {
-        return;
+        return None;
     };
 
     let window_handle = match win.window_handle() {
-        Ok(handle) => handle,
+        Ok(h) => h,
         Err(e) => {
             eprintln!("[water-reminder] Failed to get native window handle: {e}");
-            let _ = win.show();
-            return;
+            return None;
         }
     };
 
-    let hwnd = match window_handle.as_raw() {
-        RawWindowHandle::Win32(handle) => handle.hwnd.get() as HWND,
+    match window_handle.as_raw() {
+        RawWindowHandle::Win32(h) => Some(h.hwnd.get() as HWND),
         _ => {
             eprintln!("[water-reminder] Unexpected non-Win32 window handle on Windows.");
-            let _ = win.show();
-            return;
+            None
         }
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn bring_window_to_front_without_focus_on_windows(app_handle: &AppHandle) {
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        HWND_NOTOPMOST, HWND_TOPMOST, SWP_ASYNCWINDOWPOS, SWP_NOACTIVATE, SWP_NOMOVE,
+        SWP_NOSIZE, SWP_SHOWWINDOW, SW_SHOWNOACTIVATE, SetWindowPos, ShowWindow,
+    };
+
+    let Some(hwnd) = hwnd_from_main_window(app_handle) else {
+        return;
     };
 
     unsafe {
@@ -854,30 +858,13 @@ fn stop_window_attention(app_handle: &AppHandle) {
 /// `FlashWindowEx` call when the window is the currently active window.
 #[cfg(target_os = "windows")]
 fn flash_window_taskbar_windows(app_handle: &AppHandle) {
-    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
     use windows_sys::Win32::{
-        Foundation::HWND,
+        Foundation::{GetLastError, SetLastError},
         UI::WindowsAndMessaging::{FlashWindowEx, FLASHWINFO, FLASHW_ALL, FLASHW_TIMERNOFG},
     };
 
-    let Some(win) = app_handle.get_webview_window("main") else {
+    let Some(hwnd) = hwnd_from_main_window(app_handle) else {
         return;
-    };
-
-    let window_handle = match win.window_handle() {
-        Ok(h) => h,
-        Err(e) => {
-            eprintln!("[water-reminder] Failed to get native window handle: {e}");
-            return;
-        }
-    };
-
-    let hwnd = match window_handle.as_raw() {
-        RawWindowHandle::Win32(h) => h.hwnd.get() as HWND,
-        _ => {
-            eprintln!("[water-reminder] Unexpected non-Win32 window handle on Windows.");
-            return;
-        }
     };
 
     unsafe {
@@ -885,10 +872,16 @@ fn flash_window_taskbar_windows(app_handle: &AppHandle) {
             cbSize: std::mem::size_of::<FLASHWINFO>() as u32,
             hwnd,
             dwFlags: FLASHW_ALL | FLASHW_TIMERNOFG,
-            uCount: u32::MAX,
+            // uCount is ignored by the OS when FLASHW_TIMERNOFG is set; use 0.
+            uCount: 0,
             dwTimeout: 0,
         };
+        SetLastError(0);
         FlashWindowEx(&flash_info);
+        let err = GetLastError();
+        if err != 0 {
+            eprintln!("[water-reminder] FlashWindowEx failed to start taskbar flash (error code {err}).");
+        }
     }
 }
 
@@ -897,30 +890,13 @@ fn flash_window_taskbar_windows(app_handle: &AppHandle) {
 /// skip the `FlashWindowEx(FLASHW_STOP)` call when the window is active.
 #[cfg(target_os = "windows")]
 fn stop_window_attention_windows(app_handle: &AppHandle) {
-    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
     use windows_sys::Win32::{
-        Foundation::HWND,
+        Foundation::{GetLastError, SetLastError},
         UI::WindowsAndMessaging::{FlashWindowEx, FLASHWINFO, FLASHW_STOP},
     };
 
-    let Some(win) = app_handle.get_webview_window("main") else {
+    let Some(hwnd) = hwnd_from_main_window(app_handle) else {
         return;
-    };
-
-    let window_handle = match win.window_handle() {
-        Ok(h) => h,
-        Err(e) => {
-            eprintln!("[water-reminder] Failed to get native window handle: {e}");
-            return;
-        }
-    };
-
-    let hwnd = match window_handle.as_raw() {
-        RawWindowHandle::Win32(h) => h.hwnd.get() as HWND,
-        _ => {
-            eprintln!("[water-reminder] Unexpected non-Win32 window handle on Windows.");
-            return;
-        }
     };
 
     unsafe {
@@ -931,7 +907,12 @@ fn stop_window_attention_windows(app_handle: &AppHandle) {
             uCount: 0,
             dwTimeout: 0,
         };
+        SetLastError(0);
         FlashWindowEx(&flash_info);
+        let err = GetLastError();
+        if err != 0 {
+            eprintln!("[water-reminder] FlashWindowEx failed to stop taskbar flash (error code {err}).");
+        }
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -801,11 +801,24 @@ fn bring_window_to_front_without_focus_on_windows(app_handle: &AppHandle) {
 }
 
 /// Ask the OS to flash / bounce the taskbar or dock icon to attract the user's
-/// attention.  Errors are logged but not propagated.
+/// attention.
+///
+/// On Windows we call `FlashWindowEx` directly to avoid a bug in tao where
+/// `request_user_attention` skips the call entirely when the window is already
+/// the active window.  On other platforms we delegate to Tauri's built-in API.
 fn flash_window_taskbar(app_handle: &AppHandle) {
-    use tauri_runtime::UserAttentionType;
-    if let Some(win) = app_handle.get_webview_window("main") {
-        let _ = win.request_user_attention(Some(UserAttentionType::Critical));
+    #[cfg(target_os = "windows")]
+    {
+        flash_window_taskbar_windows(app_handle);
+        return;
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        use tauri_runtime::UserAttentionType;
+        if let Some(win) = app_handle.get_webview_window("main") {
+            let _ = win.request_user_attention(Some(UserAttentionType::Critical));
+        }
     }
 }
 
@@ -818,9 +831,107 @@ fn minimize_window(app_handle: &AppHandle) {
 
 /// Stop any pending taskbar flash / dock-bounce that was started by a
 /// previous call to `flash_window_taskbar`.
+///
+/// On Windows we call `FlashWindowEx` directly for the same reason as
+/// `flash_window_taskbar` — tao's early-return guard would otherwise prevent
+/// `FLASHW_STOP` from being sent when the app window is already active (which
+/// it typically is at the moment the user acknowledges a reminder).
 fn stop_window_attention(app_handle: &AppHandle) {
+    #[cfg(target_os = "windows")]
+    {
+        stop_window_attention_windows(app_handle);
+        return;
+    }
+
+    #[cfg(not(target_os = "windows"))]
     if let Some(win) = app_handle.get_webview_window("main") {
         let _ = win.request_user_attention(None);
+    }
+}
+
+/// Windows-specific: start flashing the taskbar button using the Windows API
+/// directly, bypassing tao's `request_user_attention` which skips the
+/// `FlashWindowEx` call when the window is the currently active window.
+#[cfg(target_os = "windows")]
+fn flash_window_taskbar_windows(app_handle: &AppHandle) {
+    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+    use windows_sys::Win32::{
+        Foundation::HWND,
+        UI::WindowsAndMessaging::{FlashWindowEx, FLASHWINFO, FLASHW_ALL, FLASHW_TIMERNOFG},
+    };
+
+    let Some(win) = app_handle.get_webview_window("main") else {
+        return;
+    };
+
+    let window_handle = match win.window_handle() {
+        Ok(h) => h,
+        Err(e) => {
+            eprintln!("[water-reminder] Failed to get native window handle: {e}");
+            return;
+        }
+    };
+
+    let hwnd = match window_handle.as_raw() {
+        RawWindowHandle::Win32(h) => h.hwnd.get() as HWND,
+        _ => {
+            eprintln!("[water-reminder] Unexpected non-Win32 window handle on Windows.");
+            return;
+        }
+    };
+
+    unsafe {
+        let flash_info = FLASHWINFO {
+            cbSize: std::mem::size_of::<FLASHWINFO>() as u32,
+            hwnd,
+            dwFlags: FLASHW_ALL | FLASHW_TIMERNOFG,
+            uCount: u32::MAX,
+            dwTimeout: 0,
+        };
+        FlashWindowEx(&flash_info);
+    }
+}
+
+/// Windows-specific: stop any taskbar flash unconditionally using the Windows
+/// API directly.  Unlike tao's `request_user_attention(None)`, this does not
+/// skip the `FlashWindowEx(FLASHW_STOP)` call when the window is active.
+#[cfg(target_os = "windows")]
+fn stop_window_attention_windows(app_handle: &AppHandle) {
+    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+    use windows_sys::Win32::{
+        Foundation::HWND,
+        UI::WindowsAndMessaging::{FlashWindowEx, FLASHWINFO, FLASHW_STOP},
+    };
+
+    let Some(win) = app_handle.get_webview_window("main") else {
+        return;
+    };
+
+    let window_handle = match win.window_handle() {
+        Ok(h) => h,
+        Err(e) => {
+            eprintln!("[water-reminder] Failed to get native window handle: {e}");
+            return;
+        }
+    };
+
+    let hwnd = match window_handle.as_raw() {
+        RawWindowHandle::Win32(h) => h.hwnd.get() as HWND,
+        _ => {
+            eprintln!("[water-reminder] Unexpected non-Win32 window handle on Windows.");
+            return;
+        }
+    };
+
+    unsafe {
+        let flash_info = FLASHWINFO {
+            cbSize: std::mem::size_of::<FLASHWINFO>() as u32,
+            hwnd,
+            dwFlags: FLASHW_STOP,
+            uCount: 0,
+            dwTimeout: 0,
+        };
+        FlashWindowEx(&flash_info);
     }
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Water Reminder",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "identifier": "com.waterreminder.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Bump project version to 0.1.5 in package.json, Cargo.toml and Tauri config. Add Windows-specific taskbar flash handling by calling FlashWindowEx directly (flash_window_taskbar_windows and stop_window_attention_windows) using raw_window_handle and windows_sys, with cfg gating to use tauri_runtime::request_user_attention on other platforms. This works around a tao bug where request_user_attention can skip the FlashWindowEx call when the window is already active; errors are logged and the implementation falls back gracefully when a native handle isn't available.