### PR TITLE
Add 'keep_awake' Windows wake-lock option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Settings are automatically saved to disk with a short debounce — nothing is lo
 | Taskbar / dock flash | Flashes taskbar (Windows) or bounces dock icon (macOS) |
 | Acknowledge auto-minimize | Optionally minimizes the window after `I Drank Water!` in `WaitingAck` |
 | Always-on-top while waiting | Keeps the window above all other windows during `WaitingAck`; requires *Focus window* to be enabled |
+| Prevent system sleep | Holds a Windows wake lock while the session is active so reminders fire even if the PC would otherwise sleep |
 | Theme preference | Follow system, always light, or always dark |
 | Launch auto-start | Optionally starts a fresh reminder session automatically on app launch |
 | UI flash animation | Full-screen saturation + brightness pulse on every reminder; auto-clears when you acknowledge, snooze, or stop |
@@ -87,6 +88,7 @@ Stopped → Running → (reminder fires) → WaitingAck ⟶ Running
 | Repeat sound until action | On | On / Off | Replays every 10 seconds while waiting for acknowledgment |
 | Focus window | On | On / Off | Brings window to front; on Windows this avoids stealing focus |
 | Always on top while waiting | Off | On / Off | Keeps the window above all others during `WaitingAck`; only available when *Focus window* is on |
+| Prevent system sleep | Off | On / Off | Holds a Windows wake lock while the session is active (Running, Paused, or WaitingAck); Windows only |
 | Flash taskbar | On | On / Off | Flashes taskbar / bounces dock icon on reminder |
 | Minimize on acknowledge | Off | On / Off | Minimizes the window after acknowledging a pending reminder |
 
@@ -174,7 +176,7 @@ The packaged installer is written to `src-tauri/target/release/bundle/`.
 
 ## Platform notes
 
-- **Windows** – taskbar flash uses the `Critical` attention type, which flashes both the window frame and the taskbar button until the app is focused. If **Focus window** is enabled, the app is also raised above other windows without taking keyboard focus. If **Always on top while waiting** is also enabled, the window stays above all other windows while `WaitingAck` is active and reverts to normal z-order once you acknowledge or snooze.
+- **Windows** – taskbar flash uses the `Critical` attention type, which flashes both the window frame and the taskbar button until the app is focused. If **Focus window** is enabled, the app is also raised above other windows without taking keyboard focus. If **Always on top while waiting** is also enabled, the window stays above all other windows while `WaitingAck` is active and reverts to normal z-order once you acknowledge or snooze. If **Prevent system sleep** is enabled, a `SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED)` wake lock is held on the main thread for the duration of the session, ensuring timers fire reliably even when the system would otherwise sleep.
 - **macOS** – dock bounce uses the `Critical` attention type (continuous bounce until focused); bundle identifier is `com.waterreminder.desktop`.
 - **Linux** – taskbar flash behaviour depends on the window manager (GNOME, KDE, i3, etc.) and is not guaranteed.
 - **Closing the app** – if the timer is `Stopped`, closing the window exits immediately. If a reminder session is active (`Running`, `Paused`, or `WaitingAck`), the app asks for confirmation before closing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "water-reminder",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "water-reminder",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "water-reminder",
   "private": true,
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4655,7 +4655,7 @@ dependencies = [
 
 [[package]]
 name = "water-reminder"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "raw-window-handle",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "water-reminder"
-version = "0.1.5"
+version = "0.1.6"
 description = "A configurable water reminder application built with Tauri v2"
 authors = []
 edition = "2021"
@@ -39,6 +39,7 @@ raw-window-handle = "0.6"
 windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_UI_WindowsAndMessaging",
+    "Win32_System_Power",
 ] }
 
 # ── Release profile – smaller, faster binary ──────────────────────────────

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -328,7 +328,17 @@ fn save_config(
     // system wake lock accordingly.
     if active_session {
         if config.keep_awake && !prev_keep_awake {
-            activate_wake_lock(&app_handle);
+            // Re-acquire the lock to verify the session is still active before
+            // acquiring the wake lock.  Without this check, a concurrent
+            // stop_reminders/reset_reminders could run between the earlier
+            // drop(s) and this point, leaving the system awake unexpectedly.
+            let still_active = state
+                .lock()
+                .map(|s| s.status != ReminderStatus::Stopped)
+                .unwrap_or(false);
+            if still_active {
+                activate_wake_lock(&app_handle);
+            }
         } else if !config.keep_awake && prev_keep_awake {
             deactivate_wake_lock(&app_handle);
         }
@@ -962,14 +972,21 @@ fn stop_window_attention_windows(app_handle: &AppHandle) {
 /// On other platforms this is a no-op.
 #[cfg(target_os = "windows")]
 fn activate_wake_lock(app_handle: &AppHandle) {
-    let _ = app_handle.run_on_main_thread(|| {
+    if let Err(e) = app_handle.run_on_main_thread(|| {
         use windows_sys::Win32::System::Power::{
             ES_CONTINUOUS, ES_SYSTEM_REQUIRED, SetThreadExecutionState,
         };
         unsafe {
-            SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED);
+            let result = SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED);
+            if result == 0 {
+                eprintln!(
+                    "[water-reminder] SetThreadExecutionState (activate) failed: returned 0."
+                );
+            }
         }
-    });
+    }) {
+        eprintln!("[water-reminder] activate_wake_lock: run_on_main_thread failed: {e}");
+    }
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -981,12 +998,19 @@ fn activate_wake_lock(_app_handle: &AppHandle) {}
 /// lock is currently held — it is effectively a no-op in that case.
 #[cfg(target_os = "windows")]
 fn deactivate_wake_lock(app_handle: &AppHandle) {
-    let _ = app_handle.run_on_main_thread(|| {
+    if let Err(e) = app_handle.run_on_main_thread(|| {
         use windows_sys::Win32::System::Power::{ES_CONTINUOUS, SetThreadExecutionState};
         unsafe {
-            SetThreadExecutionState(ES_CONTINUOUS);
+            let result = SetThreadExecutionState(ES_CONTINUOUS);
+            if result == 0 {
+                eprintln!(
+                    "[water-reminder] SetThreadExecutionState (deactivate) failed: returned 0."
+                );
+            }
         }
-    });
+    }) {
+        eprintln!("[water-reminder] deactivate_wake_lock: run_on_main_thread failed: {e}");
+    }
 }
 
 #[cfg(not(target_os = "windows"))]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -109,6 +109,11 @@ pub struct ReminderConfig {
     /// `WaitingAck` state.  Only has effect when `focus_window` is also `true`.
     #[serde(default)]
     pub always_on_top_while_waiting: bool,
+    /// When `true`, the system is prevented from sleeping while a reminder
+    /// session is active (Running, Paused, or WaitingAck).  Windows only;
+    /// no-op on other platforms.
+    #[serde(default)]
+    pub keep_awake: bool,
 }
 
 impl Default for ReminderConfig {
@@ -126,6 +131,7 @@ impl Default for ReminderConfig {
             flash_taskbar: true,
             minimize_on_acknowledge: false,
             always_on_top_while_waiting: false,
+            keep_awake: false,
         }
     }
 }
@@ -296,6 +302,10 @@ fn save_config(
         && s.config.require_acknowledgment
         && !config.require_acknowledgment;
 
+    // Capture the previous keep_awake value before overwriting the config so
+    // we can detect a toggle and adjust the system wake lock accordingly.
+    let prev_keep_awake = s.config.keep_awake;
+
     // Update the in-memory config so `get_status` reflects the latest settings
     // even before the user presses Start.
     s.config = config.clone();
@@ -312,6 +322,16 @@ fn save_config(
 
     if resolve_waiting_ack {
         stop_window_attention(&app_handle);
+    }
+
+    // If the keep_awake setting changed while a session is active, toggle the
+    // system wake lock accordingly.
+    if active_session {
+        if config.keep_awake && !prev_keep_awake {
+            activate_wake_lock(&app_handle);
+        } else if !config.keep_awake && prev_keep_awake {
+            deactivate_wake_lock(&app_handle);
+        }
     }
 
     // Write to disk (errors are logged, not propagated).
@@ -363,6 +383,10 @@ fn start_reminders(
     // Also persist the config that was just used to start a session.
     persist_config(&app_handle, &config);
 
+    if config.keep_awake {
+        activate_wake_lock(&app_handle);
+    }
+
     spawn_timer_thread(Arc::clone(&*state), app_handle, my_gen);
 
     Ok(snap)
@@ -386,10 +410,14 @@ fn stop_reminders(
     s.reminder_count = 0;
     // Bump generation so the timer thread exits on its next iteration.
     s.thread_generation += 1;
+    let was_keep_awake = s.config.keep_awake;
     let snap = snapshot(&s);
     drop(s);
     // Clear any pending taskbar-flash / user-attention request.
     stop_window_attention(&app_handle);
+    if was_keep_awake {
+        deactivate_wake_lock(&app_handle);
+    }
     Ok(snap)
 }
 
@@ -465,10 +493,14 @@ fn reset_reminders(
     s.remaining_when_paused = None;
     // Bump generation so the timer thread exits.
     s.thread_generation += 1;
+    let was_keep_awake = s.config.keep_awake;
     let snap = snapshot(&s);
     drop(s);
     // Clear any pending taskbar-flash / user-attention request.
     stop_window_attention(&app_handle);
+    if was_keep_awake {
+        deactivate_wake_lock(&app_handle);
+    }
     Ok(snap)
 }
 
@@ -610,8 +642,8 @@ fn spawn_timer_thread(state: SharedState, app_handle: AppHandle, my_gen: u64) {
             thread::sleep(Duration::from_millis(100));
 
             // ── Determine what to do next (hold the lock briefly) ─────────
-            // (new_count, is_last, focus_window, flash_taskbar)
-            let fire_info: Option<(u32, bool, bool, bool)>;
+            // (new_count, is_last, focus_window, flash_taskbar, deactivate_wake_lock)
+            let fire_info: Option<(u32, bool, bool, bool, bool)>;
 
             {
                 let mut s = match state.lock() {
@@ -679,6 +711,7 @@ fn spawn_timer_thread(state: SharedState, app_handle: AppHandle, my_gen: u64) {
                                 is_last,
                                 s.config.focus_window,
                                 s.config.flash_taskbar,
+                                is_last && s.config.keep_awake,
                             ));
                         }
                     }
@@ -687,7 +720,7 @@ fn spawn_timer_thread(state: SharedState, app_handle: AppHandle, my_gen: u64) {
             }
 
             // ── Send notification & emit events (lock NOT held) ───────────
-            if let Some((count, is_last, focus_window, flash_taskbar)) = fire_info {
+            if let Some((count, is_last, focus_window, flash_taskbar, release_wake_lock)) = fire_info {
                 // Send desktop notification.
                 send_notification(&app_handle);
 
@@ -707,6 +740,10 @@ fn spawn_timer_thread(state: SharedState, app_handle: AppHandle, my_gen: u64) {
                 if is_last {
                     // Notify the frontend that the session has completed.
                     let _ = app_handle.emit("reminder-completed", count);
+                    // Release any system wake lock that was held for the session.
+                    if release_wake_lock {
+                        deactivate_wake_lock(&app_handle);
+                    }
                     break; // Exit the timer thread.
                 }
             }
@@ -916,6 +953,45 @@ fn stop_window_attention_windows(app_handle: &AppHandle) {
     }
 }
 
+// ── Wake-lock helpers ─────────────────────────────────────────────────────────
+
+/// Ask the OS not to sleep while a reminder session is active.
+///
+/// On Windows we post a `SetThreadExecutionState` call to the main thread so
+/// the wake lock is always held—and later released—by the same thread.
+/// On other platforms this is a no-op.
+#[cfg(target_os = "windows")]
+fn activate_wake_lock(app_handle: &AppHandle) {
+    let _ = app_handle.run_on_main_thread(|| {
+        use windows_sys::Win32::System::Power::{
+            ES_CONTINUOUS, ES_SYSTEM_REQUIRED, SetThreadExecutionState,
+        };
+        unsafe {
+            SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED);
+        }
+    });
+}
+
+#[cfg(not(target_os = "windows"))]
+fn activate_wake_lock(_app_handle: &AppHandle) {}
+
+/// Release the wake lock previously acquired by `activate_wake_lock`.
+///
+/// Calling `SetThreadExecutionState(ES_CONTINUOUS)` is safe even when no wake
+/// lock is currently held — it is effectively a no-op in that case.
+#[cfg(target_os = "windows")]
+fn deactivate_wake_lock(app_handle: &AppHandle) {
+    let _ = app_handle.run_on_main_thread(|| {
+        use windows_sys::Win32::System::Power::{ES_CONTINUOUS, SetThreadExecutionState};
+        unsafe {
+            SetThreadExecutionState(ES_CONTINUOUS);
+        }
+    });
+}
+
+#[cfg(not(target_os = "windows"))]
+fn deactivate_wake_lock(_app_handle: &AppHandle) {}
+
 // ── Application entry point ───────────────────────────────────────────────────
 
 /// Called from `main.rs`.  Builds the Tauri application, registers plugins
@@ -941,6 +1017,7 @@ pub fn run() {
                 // somehow corrupt we simply keep the built-in defaults.
                 if validate_config(&saved_config).is_ok() {
                     let mut auto_start_generation = None;
+                    let mut auto_start_keep_awake = false;
 
                     if let Ok(mut s) = app.state::<SharedState>().lock() {
                         s.config = saved_config;
@@ -955,12 +1032,16 @@ pub fn run() {
                             );
                             s.thread_generation += 1;
                             auto_start_generation = Some(s.thread_generation);
+                            auto_start_keep_awake = s.config.keep_awake;
                         }
                     }
 
                     if let Some(my_gen) = auto_start_generation {
                         let shared_state = app.state::<SharedState>();
                         spawn_timer_thread(Arc::clone(&*shared_state), app.handle().clone(), my_gen);
+                        if auto_start_keep_awake {
+                            activate_wake_lock(app.handle());
+                        }
                     }
 
                     // When both auto-start and minimize-on-acknowledge are

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Water Reminder",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "identifier": "com.waterreminder.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,9 @@ interface ReminderConfig {
   /** When true, the window is kept always on top while waiting for acknowledgment.
    *  Only has effect when focus_window is also true. */
   always_on_top_while_waiting: boolean;
+  /** When true, the system is prevented from sleeping while a session is active.
+   *  Windows only; no-op on other platforms. */
+  keep_awake: boolean;
 }
 
 /** Possible states of the reminder timer. */
@@ -121,6 +124,7 @@ const DEFAULT_CONFIG: ReminderConfig = {
   flash_taskbar: true,
   minimize_on_acknowledge: false,
   always_on_top_while_waiting: false,
+  keep_awake: false,
 };
 
 /** Default state when the app first loads. */
@@ -165,6 +169,7 @@ function App() {
   const [formAlwaysOnTopWhileWaiting, setFormAlwaysOnTopWhileWaiting] = useState(
     DEFAULT_CONFIG.always_on_top_while_waiting,
   );
+  const [formKeepAwake, setFormKeepAwake] = useState(DEFAULT_CONFIG.keep_awake);
   const [systemPrefersDark, setSystemPrefersDark] = useState(getSystemPrefersDark);
 
   // Whether to show the snooze button prominently (set true after a reminder fires).
@@ -275,6 +280,7 @@ function App() {
         setFormFlashTaskbar(snapshot.config.flash_taskbar);
         setFormMinimizeOnAcknowledge(snapshot.config.minimize_on_acknowledge);
         setFormAlwaysOnTopWhileWaiting(snapshot.config.always_on_top_while_waiting);
+        setFormKeepAwake(snapshot.config.keep_awake);
         // Mark the initial load as done so subsequent changes auto-save.
         isInitialLoadRef.current = false;
       })
@@ -309,6 +315,7 @@ function App() {
         flash_taskbar: formFlashTaskbar,
         minimize_on_acknowledge: formMinimizeOnAcknowledge,
         always_on_top_while_waiting: formAlwaysOnTopWhileWaiting,
+        keep_awake: formKeepAwake,
       };
 
       // save_config validates, persists to disk, and updates the in-memory config.
@@ -337,6 +344,7 @@ function App() {
     formFlashTaskbar,
     formMinimizeOnAcknowledge,
     formAlwaysOnTopWhileWaiting,
+    formKeepAwake,
   ]);
 
   useEffect(() => {
@@ -569,6 +577,7 @@ function App() {
     flash_taskbar: formFlashTaskbar,
     minimize_on_acknowledge: formMinimizeOnAcknowledge,
     always_on_top_while_waiting: formAlwaysOnTopWhileWaiting,
+    keep_awake: formKeepAwake,
   }), [
     formInterval,
     isInfinite,
@@ -583,6 +592,7 @@ function App() {
     formFlashTaskbar,
     formMinimizeOnAcknowledge,
     formAlwaysOnTopWhileWaiting,
+    formKeepAwake,
   ]);
 
   useEffect(() => {
@@ -1105,6 +1115,14 @@ function App() {
                     onChange={(e) => setFormMinimizeOnAcknowledge(e.target.checked)}
                   />
                   <span>Minimize window to taskbar when acknowledging a reminder</span>
+                </label>
+                <label className="toggle-label">
+                  <input
+                    type="checkbox"
+                    checked={formKeepAwake}
+                    onChange={(e) => setFormKeepAwake(e.target.checked)}
+                  />
+                  <span>Prevent system sleep while session is active (Windows)</span>
                 </label>
               </div>
             </fieldset>


### PR DESCRIPTION
Introduce a new keep_awake setting to prevent system sleep on Windows while a reminder session is active. Adds the config field, UI checkbox, and default value (false), persists and reflects changes immediately, and ensures the wake lock is acquired on session start/auto-start and released on stop, reset, or when a session completes. Implementation uses SetThreadExecutionState on the main thread (no-op on non-Windows), with the required Win32_System_Power feature enabled in Cargo.toml. README and app version metadata updated to document the new option.