### PR TITLE
Add Windows minimize-to-tray support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Settings are automatically saved to disk with a short debounce — nothing is lo
 | Taskbar flash | Flashes the Windows taskbar button to signal a pending reminder |
 | Acknowledge auto-minimize | Optionally minimizes the window when starting reminders and after `I Drank Water!` in `WaitingAck` |
 | Always-on-top while waiting | Keeps the window above all other windows during `WaitingAck`; requires *Focus window* to be enabled |
+| Minimize to system tray | Minimizes/closes the window to the Windows system tray (left-click icon to restore, right-click for menu); Windows only |
 | Prevent system sleep | Holds a Windows wake lock while the session is active so reminders fire even if the PC would otherwise sleep |
 | Virtual desktop aware | When a reminder fires and the app is on a different Windows virtual desktop, it is automatically moved to the active one |
 | Theme preference | Follow system, always light, or always dark |
@@ -88,6 +89,7 @@ Stopped → Running → (reminder fires) → WaitingAck ⟶ Running
 | Repeat sound until action | On | On / Off | Replays every 10 seconds while waiting for acknowledgment |
 | Focus window | On | On / Off | Brings window to front; on Windows this avoids stealing focus |
 | Always on top while waiting | Off | On / Off | Keeps the window above all others during `WaitingAck`; only available when *Focus window* is on |
+| Minimize to system tray | Off | On / Off | Minimizes or closes the window to the Windows system tray instead of the taskbar; left-click the tray icon to restore, right-click for menu; Windows only |
 | Prevent system sleep | Off | On / Off | Holds a Windows wake lock while the session is active (Running, Paused, or WaitingAck); Windows only |
 | Flash taskbar | On | On / Off | Flashes the Windows taskbar button on reminder |
 | Minimize on acknowledge | Off | On / Off | Minimizes the window when starting reminders and after acknowledging a pending reminder |

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Settings are automatically saved to disk with a short debounce — nothing is lo
 | Taskbar flash | Flashes the Windows taskbar button to signal a pending reminder |
 | Acknowledge auto-minimize | Optionally minimizes the window when starting reminders and after `I Drank Water!` in `WaitingAck` |
 | Always-on-top while waiting | Keeps the window above all other windows during `WaitingAck`; requires *Focus window* to be enabled |
-| Minimize to system tray | Minimizes/closes the window to the Windows system tray (left-click icon to restore, right-click for menu); Windows only |
+| Minimize to system tray | Minimizes the window to the Windows system tray (left-click icon to restore, right-click for menu); Windows only |
 | Prevent system sleep | Holds a Windows wake lock while the session is active so reminders fire even if the PC would otherwise sleep |
 | Virtual desktop aware | When a reminder fires and the app is on a different Windows virtual desktop, it is automatically moved to the active one |
 | Theme preference | Follow system, always light, or always dark |
@@ -89,7 +89,7 @@ Stopped → Running → (reminder fires) → WaitingAck ⟶ Running
 | Repeat sound until action | On | On / Off | Replays every 10 seconds while waiting for acknowledgment |
 | Focus window | On | On / Off | Brings window to front; on Windows this avoids stealing focus |
 | Always on top while waiting | Off | On / Off | Keeps the window above all others during `WaitingAck`; only available when *Focus window* is on |
-| Minimize to system tray | Off | On / Off | Minimizes or closes the window to the Windows system tray instead of the taskbar; left-click the tray icon to restore, right-click for menu; Windows only |
+| Minimize to system tray | Off | On / Off | Minimizes the window to the Windows system tray instead of the taskbar; left-click the tray icon to restore, right-click for menu; Windows only |
 | Prevent system sleep | Off | On / Off | Holds a Windows wake lock while the session is active (Running, Paused, or WaitingAck); Windows only |
 | Flash taskbar | On | On / Off | Flashes the Windows taskbar button on reminder |
 | Minimize on acknowledge | Off | On / Off | Minimizes the window when starting reminders and after acknowledging a pending reminder |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "water-reminder",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "water-reminder",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",
@@ -1276,3 +1276,4 @@
     }
   }
 }
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "water-reminder",
   "private": true,
-  "version": "0.1.7",
+  "version": "0.1.8",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4657,7 +4657,7 @@ dependencies = [
 
 [[package]]
 name = "water-reminder"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "raw-window-handle",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "water-reminder"
-version = "0.1.7"
+version = "0.1.8"
 description = "A configurable water reminder application built with Tauri v2"
 authors = []
 edition = "2021"
@@ -16,7 +16,7 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 # Core Tauri framework
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["tray-icon"] }
 
 # Public runtime types used by window attention APIs
 tauri-runtime = "2.10.1"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "dialog:default",
     "notification:default",
     "core:window:allow-destroy",
-    "core:window:allow-set-always-on-top"
+    "core:window:allow-set-always-on-top",
+    "core:window:allow-hide"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -114,8 +114,8 @@ pub struct ReminderConfig {
     /// no-op on other platforms.
     #[serde(default)]
     pub keep_awake: bool,
-    /// When `true`, minimizing or closing the window hides it to the system
-    /// tray instead of minimizing to the taskbar / exiting.  Windows only.
+    /// When `true`, minimizing the window hides it to the system tray instead
+    /// of minimizing it to the taskbar. Windows only.
     #[serde(default)]
     pub minimize_to_tray: bool,
 }
@@ -263,6 +263,14 @@ fn persist_config(app_handle: &AppHandle, config: &ReminderConfig) {
     }
 }
 
+#[cfg(target_os = "windows")]
+fn sync_minimize_to_tray_state(app_handle: &AppHandle, minimize_to_tray: bool) {
+    MINIMIZE_TO_TRAY.store(minimize_to_tray, std::sync::atomic::Ordering::Relaxed);
+    if let Some(tray) = app_handle.tray_by_id("main-tray") {
+        let _ = tray.set_visible(minimize_to_tray);
+    }
+}
+
 /// Try to load a previously saved `ReminderConfig` from the on-disk store.
 /// Returns `None` if no config has been saved yet or if it cannot be parsed.
 fn load_config(app_handle: &AppHandle) -> Option<ReminderConfig> {
@@ -355,10 +363,7 @@ fn save_config(
     // Keep the tray-icon visibility and atomic in sync with the new setting.
     #[cfg(target_os = "windows")]
     {
-        MINIMIZE_TO_TRAY.store(config.minimize_to_tray, std::sync::atomic::Ordering::Relaxed);
-        if let Some(tray) = app_handle.tray_by_id("main-tray") {
-            let _ = tray.set_visible(config.minimize_to_tray);
-        }
+        sync_minimize_to_tray_state(&app_handle, config.minimize_to_tray);
     }
 
     Ok(snap)
@@ -406,6 +411,11 @@ fn start_reminders(
 
     // Also persist the config that was just used to start a session.
     persist_config(&app_handle, &config);
+
+    #[cfg(target_os = "windows")]
+    {
+        sync_minimize_to_tray_state(&app_handle, config.minimize_to_tray);
+    }
 
     if config.keep_awake {
         activate_wake_lock(&app_handle);
@@ -885,6 +895,7 @@ unsafe extern "system" fn minimize_intercept_wndproc(
 #[cfg(target_os = "windows")]
 fn install_minimize_wndproc_hook(app_handle: &AppHandle) {
     use std::sync::atomic::Ordering;
+    use windows_sys::Win32::Foundation::{GetLastError, SetLastError};
     use windows_sys::Win32::UI::WindowsAndMessaging::{
         GWLP_WNDPROC, GetWindowLongPtrW, SetWindowLongPtrW,
     };
@@ -906,7 +917,15 @@ fn install_minimize_wndproc_hook(app_handle: &AppHandle) {
             return;
         }
         ORIGINAL_WNDPROC.store(orig, std::sync::atomic::Ordering::Relaxed);
-        SetWindowLongPtrW(hwnd, GWLP_WNDPROC, minimize_intercept_wndproc as *const () as isize);
+        SetLastError(0);
+        let prev = SetWindowLongPtrW(hwnd, GWLP_WNDPROC, minimize_intercept_wndproc as *const () as isize);
+        if prev == 0 {
+            let err = GetLastError();
+            if err != 0 {
+                ORIGINAL_WNDPROC.store(0, std::sync::atomic::Ordering::Relaxed);
+                eprintln!("[water-reminder] SetWindowLongPtrW failed; cannot install minimize hook (error code {err}).");
+            }
+        }
     }
 }
 
@@ -1298,7 +1317,7 @@ pub fn run() {
                 .unwrap_or(false);
 
             #[cfg(target_os = "windows")]
-            MINIMIZE_TO_TRAY.store(tray_visible, std::sync::atomic::Ordering::Relaxed);
+            sync_minimize_to_tray_state(app.handle(), tray_visible);
 
             {
                 use tauri::menu::{Menu, MenuItem};
@@ -1310,8 +1329,15 @@ pub fn run() {
                     MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
                 let menu = Menu::with_items(app, &[&show_item, &quit_item])?;
 
+                let tray_icon = app.default_window_icon().cloned().ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        "default window icon not configured; cannot create tray icon",
+                    )
+                })?;
+
                 let tray = TrayIconBuilder::with_id("main-tray")
-                    .icon(app.default_window_icon().unwrap().clone())
+                    .icon(tray_icon)
                     .menu(&menu)
                     .tooltip("Water Reminder")
                     .show_menu_on_left_click(false)
@@ -1333,11 +1359,6 @@ pub fn run() {
                     .build(app)?;
 
                 tray.set_visible(tray_visible)?;
-                // Ensure the TrayIcon value (and its event handlers) are not
-                // dropped when this block exits.  Tauri holds its own Arc clone
-                // in its tray manager, but we keep ours as a safety net to
-                // guarantee the callbacks remain alive for the process lifetime.
-                std::mem::forget(tray);
             }
 
             // Install the WndProc hook that redirects OS minimize to tray.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -114,6 +114,10 @@ pub struct ReminderConfig {
     /// no-op on other platforms.
     #[serde(default)]
     pub keep_awake: bool,
+    /// When `true`, minimizing or closing the window hides it to the system
+    /// tray instead of minimizing to the taskbar / exiting.  Windows only.
+    #[serde(default)]
+    pub minimize_to_tray: bool,
 }
 
 impl Default for ReminderConfig {
@@ -132,6 +136,7 @@ impl Default for ReminderConfig {
             minimize_on_acknowledge: false,
             always_on_top_while_waiting: false,
             keep_awake: false,
+            minimize_to_tray: false,
         }
     }
 }
@@ -346,6 +351,15 @@ fn save_config(
 
     // Write to disk (errors are logged, not propagated).
     persist_config(&app_handle, &config);
+
+    // Keep the tray-icon visibility and atomic in sync with the new setting.
+    #[cfg(target_os = "windows")]
+    {
+        MINIMIZE_TO_TRAY.store(config.minimize_to_tray, std::sync::atomic::Ordering::Relaxed);
+        if let Some(tray) = app_handle.tray_by_id("main-tray") {
+            let _ = tray.set_visible(config.minimize_to_tray);
+        }
+    }
 
     Ok(snap)
 }
@@ -801,6 +815,101 @@ fn bring_window_to_front(app_handle: &AppHandle) {
     }
 }
 
+// ── Windows system-tray / minimize-intercept globals ─────────────────────────
+
+/// Set to `true` while the user has enabled the "minimize to tray" option.
+/// Read from the WndProc callback and from `minimize_window`, both of which
+/// cannot take normal Rust parameters at their call sites.
+#[cfg(target_os = "windows")]
+static MINIMIZE_TO_TRAY: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// The original window procedure, saved so the subclassed proc can forward
+/// unhandled messages correctly and restore it on `WM_NCDESTROY`.
+#[cfg(target_os = "windows")]
+static ORIGINAL_WNDPROC: std::sync::atomic::AtomicIsize =
+    std::sync::atomic::AtomicIsize::new(0);
+
+/// Window procedure that intercepts `WM_SYSCOMMAND / SC_MINIMIZE` when
+/// "minimize to tray" is active and hides the window instead of minimizing it.
+/// All other messages are forwarded to the original proc.
+#[cfg(target_os = "windows")]
+unsafe extern "system" fn minimize_intercept_wndproc(
+    hwnd: windows_sys::Win32::Foundation::HWND,
+    msg: u32,
+    wparam: windows_sys::Win32::Foundation::WPARAM,
+    lparam: windows_sys::Win32::Foundation::LPARAM,
+) -> windows_sys::Win32::Foundation::LRESULT {
+    use std::sync::atomic::Ordering;
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        CallWindowProcW, GWLP_WNDPROC, SC_MINIMIZE, SW_HIDE, SetWindowLongPtrW, ShowWindow,
+        WM_NCDESTROY, WM_SYSCOMMAND,
+    };
+
+    if msg == WM_SYSCOMMAND && (wparam & 0xFFF0) == SC_MINIMIZE as usize {
+        if MINIMIZE_TO_TRAY.load(Ordering::Relaxed) {
+            ShowWindow(hwnd, SW_HIDE);
+            return 0;
+        }
+    }
+
+    // Restore the original WndProc before the window is destroyed so that
+    // we leave no dangling subclass reference behind.
+    if msg == WM_NCDESTROY {
+        let orig = ORIGINAL_WNDPROC.load(Ordering::Relaxed);
+        if orig != 0 {
+            SetWindowLongPtrW(hwnd, GWLP_WNDPROC, orig);
+        }
+    }
+
+    let orig = ORIGINAL_WNDPROC.load(Ordering::Relaxed);
+    if orig == 0 {
+        return 0; // Safety fallback; should never reach here in normal use.
+    }
+
+    // Safety: `orig` holds the function pointer that was stored by
+    // `install_minimize_wndproc_hook`.  Its type matches the WNDPROC signature.
+    type WndProcFn = unsafe extern "system" fn(
+        windows_sys::Win32::Foundation::HWND,
+        u32,
+        windows_sys::Win32::Foundation::WPARAM,
+        windows_sys::Win32::Foundation::LPARAM,
+    ) -> windows_sys::Win32::Foundation::LRESULT;
+    let orig_fn: WndProcFn = std::mem::transmute(orig as usize);
+    CallWindowProcW(Some(orig_fn), hwnd, msg, wparam, lparam)
+}
+
+/// Subclass the main window to intercept minimize requests.
+/// Safe to call only once; subsequent calls are no-ops (guarded by
+/// `ORIGINAL_WNDPROC`).
+#[cfg(target_os = "windows")]
+fn install_minimize_wndproc_hook(app_handle: &AppHandle) {
+    use std::sync::atomic::Ordering;
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        GWLP_WNDPROC, GetWindowLongPtrW, SetWindowLongPtrW,
+    };
+
+    // Guard against double-install.
+    if ORIGINAL_WNDPROC.load(Ordering::Relaxed) != 0 {
+        return;
+    }
+
+    let Some(hwnd) = hwnd_from_main_window(app_handle) else {
+        eprintln!("[water-reminder] Could not get HWND; OS minimize button will not redirect to tray.");
+        return;
+    };
+
+    unsafe {
+        let orig = GetWindowLongPtrW(hwnd, GWLP_WNDPROC);
+        if orig == 0 {
+            eprintln!("[water-reminder] GetWindowLongPtrW returned 0; cannot install minimize hook.");
+            return;
+        }
+        ORIGINAL_WNDPROC.store(orig, std::sync::atomic::Ordering::Relaxed);
+        SetWindowLongPtrW(hwnd, GWLP_WNDPROC, minimize_intercept_wndproc as *const () as isize);
+    }
+}
+
 #[cfg(target_os = "windows")]
 fn hwnd_from_main_window(app_handle: &AppHandle) -> Option<windows_sys::Win32::Foundation::HWND> {
     use raw_window_handle::{HasWindowHandle, RawWindowHandle};
@@ -950,9 +1059,48 @@ fn flash_window_taskbar(app_handle: &AppHandle) {
 }
 
 /// Minimize the main window to the taskbar / dock.
+/// When "minimize to tray" is active on Windows, hides to the tray instead.
 fn minimize_window(app_handle: &AppHandle) {
     if let Some(win) = app_handle.get_webview_window("main") {
+        #[cfg(target_os = "windows")]
+        if MINIMIZE_TO_TRAY.load(std::sync::atomic::Ordering::Relaxed) {
+            let _ = win.hide();
+            return;
+        }
         let _ = win.minimize();
+    }
+}
+
+/// Restore the window from the system tray.
+///
+/// On Windows we call Win32 directly (`ShowWindow` + `SetForegroundWindow`)
+/// so the call succeeds even if Tauri's internal visibility cache is out of
+/// sync with the OS state — which happens when the WndProc intercept hid the
+/// window via a raw `ShowWindow(SW_HIDE)` call that bypassed Tauri's API.
+fn restore_window_from_tray(app_handle: &AppHandle) {
+    #[cfg(target_os = "windows")]
+    {
+        let Some(hwnd) = hwnd_from_main_window(app_handle) else {
+            return;
+        };
+        let hwnd_val = hwnd as usize;
+        let _ = app_handle.run_on_main_thread(move || {
+            use windows_sys::Win32::UI::WindowsAndMessaging::{
+                SetForegroundWindow, ShowWindow, SW_SHOW,
+            };
+            let hwnd = hwnd_val as windows_sys::Win32::Foundation::HWND;
+            unsafe {
+                ShowWindow(hwnd, SW_SHOW);
+                SetForegroundWindow(hwnd);
+            }
+        });
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    if let Some(win) = app_handle.get_webview_window("main") {
+        let _ = win.show();
+        let _ = win.unminimize();
+        let _ = win.set_focus();
     }
 }
 
@@ -1112,13 +1260,14 @@ pub fn run() {
         // `get_status` returns the correct settings from the very first call,
         // and optionally auto-start a fresh reminder session.
         .setup(|app| {
+            let mut auto_start_generation: Option<u64> = None;
+            let mut auto_start_keep_awake = false;
+            let mut auto_start_minimize = false;
+
             if let Some(saved_config) = load_config(app.handle()) {
                 // Validate the stored config before applying it; if it is
                 // somehow corrupt we simply keep the built-in defaults.
                 if validate_config(&saved_config).is_ok() {
-                    let mut auto_start_generation = None;
-                    let mut auto_start_keep_awake = false;
-
                     if let Ok(mut s) = app.state::<SharedState>().lock() {
                         s.config = saved_config;
 
@@ -1133,33 +1282,85 @@ pub fn run() {
                             s.thread_generation += 1;
                             auto_start_generation = Some(s.thread_generation);
                             auto_start_keep_awake = s.config.keep_awake;
-                        }
-                    }
-
-                    if let Some(my_gen) = auto_start_generation {
-                        let shared_state = app.state::<SharedState>();
-                        spawn_timer_thread(Arc::clone(&*shared_state), app.handle().clone(), my_gen);
-                        if auto_start_keep_awake {
-                            activate_wake_lock(app.handle());
-                        }
-                    }
-
-                    // When both auto-start and minimize-on-acknowledge are
-                    // enabled the user intends to run the app silently in the
-                    // background, so start with the window already minimized.
-                    let start_minimized = app
-                        .state::<SharedState>()
-                        .lock()
-                        .map(|s| s.config.auto_start && s.config.minimize_on_acknowledge)
-                        .unwrap_or(false);
-
-                    if start_minimized {
-                        if let Some(win) = app.get_webview_window("main") {
-                            let _ = win.minimize();
+                            auto_start_minimize = s.config.minimize_on_acknowledge;
                         }
                     }
                 }
             }
+
+            // ── Tray icon and minimize hook ────────────────────────────────
+            // Always run regardless of whether a saved config exists so that
+            // the tray is available and the hook is installed from the start.
+            let tray_visible = app
+                .state::<SharedState>()
+                .lock()
+                .map(|s| s.config.minimize_to_tray)
+                .unwrap_or(false);
+
+            #[cfg(target_os = "windows")]
+            MINIMIZE_TO_TRAY.store(tray_visible, std::sync::atomic::Ordering::Relaxed);
+
+            {
+                use tauri::menu::{Menu, MenuItem};
+                use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
+
+                let show_item =
+                    MenuItem::with_id(app, "show", "Show Water Reminder", true, None::<&str>)?;
+                let quit_item =
+                    MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
+                let menu = Menu::with_items(app, &[&show_item, &quit_item])?;
+
+                let tray = TrayIconBuilder::with_id("main-tray")
+                    .icon(app.default_window_icon().unwrap().clone())
+                    .menu(&menu)
+                    .tooltip("Water Reminder")
+                    .show_menu_on_left_click(false)
+                    .on_menu_event(|app, event| match event.id.as_ref() {
+                        "show" => restore_window_from_tray(app),
+                        "quit" => app.exit(0),
+                        _ => {}
+                    })
+                    .on_tray_icon_event(|tray, event| {
+                        if let TrayIconEvent::Click {
+                            button: MouseButton::Left,
+                            button_state: MouseButtonState::Up,
+                            ..
+                        } = event
+                        {
+                            restore_window_from_tray(tray.app_handle());
+                        }
+                    })
+                    .build(app)?;
+
+                tray.set_visible(tray_visible)?;
+                // Ensure the TrayIcon value (and its event handlers) are not
+                // dropped when this block exits.  Tauri holds its own Arc clone
+                // in its tray manager, but we keep ours as a safety net to
+                // guarantee the callbacks remain alive for the process lifetime.
+                std::mem::forget(tray);
+            }
+
+            // Install the WndProc hook that redirects OS minimize to tray.
+            #[cfg(target_os = "windows")]
+            install_minimize_wndproc_hook(app.handle());
+
+            // ── Auto-start ────────────────────────────────────────────────
+            if let Some(my_gen) = auto_start_generation {
+                let shared_state = app.state::<SharedState>();
+                spawn_timer_thread(Arc::clone(&*shared_state), app.handle().clone(), my_gen);
+                if auto_start_keep_awake {
+                    activate_wake_lock(app.handle());
+                }
+            }
+
+            // When both auto-start and minimize-on-acknowledge are enabled the
+            // user intends to run the app silently in the background, so start
+            // with the window already minimized (or hidden to tray when that
+            // setting is also on, since minimize_window respects MINIMIZE_TO_TRAY).
+            if auto_start_minimize {
+                minimize_window(app.handle());
+            }
+
             Ok(())
         })
         // Register all IPC commands exposed to the frontend.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Water Reminder",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "identifier": "com.waterreminder.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,7 +41,7 @@ interface ReminderConfig {
   /** When true, the system is prevented from sleeping while a session is active.
    *  Windows only; no-op on other platforms. */
   keep_awake: boolean;
-  /** When true, minimizing or closing the window hides it to the system tray.
+  /** When true, minimizing the window hides it to the system tray.
    *  Windows only. */
   minimize_to_tray: boolean;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,9 @@ interface ReminderConfig {
   /** When true, the system is prevented from sleeping while a session is active.
    *  Windows only; no-op on other platforms. */
   keep_awake: boolean;
+  /** When true, minimizing or closing the window hides it to the system tray.
+   *  Windows only. */
+  minimize_to_tray: boolean;
 }
 
 /** Possible states of the reminder timer. */
@@ -125,6 +128,7 @@ const DEFAULT_CONFIG: ReminderConfig = {
   minimize_on_acknowledge: false,
   always_on_top_while_waiting: false,
   keep_awake: false,
+  minimize_to_tray: false,
 };
 
 /** Default state when the app first loads. */
@@ -170,6 +174,7 @@ function App() {
     DEFAULT_CONFIG.always_on_top_while_waiting,
   );
   const [formKeepAwake, setFormKeepAwake] = useState(DEFAULT_CONFIG.keep_awake);
+  const [formMinimizeToTray, setFormMinimizeToTray] = useState(DEFAULT_CONFIG.minimize_to_tray);
   const [systemPrefersDark, setSystemPrefersDark] = useState(getSystemPrefersDark);
 
   // Whether to show the snooze button prominently (set true after a reminder fires).
@@ -281,6 +286,7 @@ function App() {
         setFormMinimizeOnAcknowledge(snapshot.config.minimize_on_acknowledge);
         setFormAlwaysOnTopWhileWaiting(snapshot.config.always_on_top_while_waiting);
         setFormKeepAwake(snapshot.config.keep_awake);
+        setFormMinimizeToTray(snapshot.config.minimize_to_tray);
         // Mark the initial load as done so subsequent changes auto-save.
         isInitialLoadRef.current = false;
       })
@@ -316,6 +322,7 @@ function App() {
         minimize_on_acknowledge: formMinimizeOnAcknowledge,
         always_on_top_while_waiting: formAlwaysOnTopWhileWaiting,
         keep_awake: formKeepAwake,
+        minimize_to_tray: formMinimizeToTray,
       };
 
       // save_config validates, persists to disk, and updates the in-memory config.
@@ -345,6 +352,7 @@ function App() {
     formMinimizeOnAcknowledge,
     formAlwaysOnTopWhileWaiting,
     formKeepAwake,
+    formMinimizeToTray,
   ]);
 
   useEffect(() => {
@@ -576,6 +584,7 @@ function App() {
     minimize_on_acknowledge: formMinimizeOnAcknowledge,
     always_on_top_while_waiting: formAlwaysOnTopWhileWaiting,
     keep_awake: formKeepAwake,
+    minimize_to_tray: formMinimizeToTray,
   }), [
     formInterval,
     isInfinite,
@@ -591,6 +600,7 @@ function App() {
     formMinimizeOnAcknowledge,
     formAlwaysOnTopWhileWaiting,
     formKeepAwake,
+    formMinimizeToTray,
   ]);
 
   useEffect(() => {
@@ -1121,6 +1131,14 @@ function App() {
                     onChange={(e) => setFormKeepAwake(e.target.checked)}
                   />
                   <span>Prevent system sleep while session is active (Windows)</span>
+                </label>
+                <label className="toggle-label">
+                  <input
+                    type="checkbox"
+                    checked={formMinimizeToTray}
+                    onChange={(e) => setFormMinimizeToTray(e.target.checked)}
+                  />
+                  <span>Minimize to system tray instead of taskbar (Windows)</span>
                 </label>
               </div>
             </fieldset>


### PR DESCRIPTION
Introduce a Windows-only "minimize to tray" option across frontend and backend so the app can hide to the system tray instead of minimizing to the taskbar. Frontend: add minimize_to_tray to the config type, default, state hooks, save/load wiring, and a checkbox in the settings UI. Backend (Tauri/Rust): add ReminderConfig.minimize_to_tray, persist and sync the setting, add a tray icon + menu (Show / Quit), implement a Win32 WndProc hook that intercepts minimize requests and hides the window to tray, and provide a restore routine that raises the window. Also install the hook on startup, ensure auto-start/minimize interactions respect the new setting, add the tauri "tray-icon" feature and window:allow-hide capability, and bump app version to 0.1.8. Windows-only behavior; other platforms remain unaffected.